### PR TITLE
Remove deprecated U prefix, fixes Python 3.9

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -213,7 +213,7 @@ def parse_setup_cfg():
     else:
         parts = []
         for nm in v.split():
-            fp = open(nm, "rU")
+            fp = open(nm, "r")
             parts.append(fp.read())
             fp.close()
 


### PR DESCRIPTION
From a Fedora bug report: https://bugzilla.redhat.com/show_bug.cgi?id=1792939

---

python-altgraph fails to build with Python 3.9.0a2.

```
+ /usr/bin/python3 setup.py build '--executable=/usr/bin/python3 -s'
Traceback (most recent call last):
  File "/builddir/build/BUILD/altgraph-0.16.1/setup.py", line 872, in <module>
    metadata = parse_setup_cfg()
  File "/builddir/build/BUILD/altgraph-0.16.1/setup.py", line 229, in parse_setup_cfg
    fp = open(nm, 'rU')
ValueError: invalid mode: 'rU'
For the build logs, see:
https://copr-be.cloud.fedoraproject.org/results/@python/python3.9/fedora-rawhide-x86_64/01160875-python-altgraph/
```

See https://docs.python.org/3.9/whatsnew/3.9.html#changes-in-the-python-api

"open(), io.open(), codecs.open() and fileinput.FileInput no longer accept 'U' (“universal newline”) in the file mode. This flag was deprecated since Python 3.3. In Python 3, the “universal newline” is used by default when a file is open in text mode. The newline parameter of open() controls how universal newlines works."

---

# master

py39 fails (py34 not installed)

```console
$ tox --parallel auto
GLOB sdist-make: /private/tmp/altgraph/setup.py
⠼ [4] isort | black | py27 | py34ERROR: invocation failed (exit code 1), logfile: /private/tmp/altgraph/.tox/py34/log/py34-2.log
================================================================= log start =================================================================
py34 create: /private/tmp/altgraph/.tox/py34
ERROR: InterpreterNotFound: python3.4

================================================================== log end ==================================================================
✖ FAIL py34 in 6.639 seconds
✔ OK black in 12.022 seconds
✔ OK isort in 12.231 seconds
✔ OK py27 in 17.583 seconds
✔ OK py35 in 17.44 seconds
✔ OK py37 in 17.671 seconds
✔ OK py36 in 18.656 seconds
⠹ [4] py38 | py39 | flake8 | coverage-reportERROR: invocation failed (exit code 1), logfile: /private/tmp/altgraph/.tox/py39/log/py39-16.log
================================================================= log start =================================================================
py39 inst-nodeps: /private/tmp/altgraph/.tox/.tmp/package/14/altgraph-0.16.1.zip
ERROR: invocation failed (exit code 1), logfile: /private/tmp/altgraph/.tox/py39/log/py39-17.log
================================== log start ===================================
Processing ./.tox/.tmp/package/14/altgraph-0.16.1.zip
    ERROR: Command errored out with exit status 1:
     command: /private/tmp/altgraph/.tox/py39/bin/python -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/private/var/folders/kt/j77sf4_n6fnbx6pg199rbx700000gn/T/pip-req-build-7ej22y0s/setup.py'"'"'; __file__='"'"'/private/var/folders/kt/j77sf4_n6fnbx6pg199rbx700000gn/T/pip-req-build-7ej22y0s/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' egg_info --egg-base /private/var/folders/kt/j77sf4_n6fnbx6pg199rbx700000gn/T/pip-req-build-7ej22y0s/pip-egg-info
         cwd: /private/var/folders/kt/j77sf4_n6fnbx6pg199rbx700000gn/T/pip-req-build-7ej22y0s/
    Complete output (7 lines):
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/private/var/folders/kt/j77sf4_n6fnbx6pg199rbx700000gn/T/pip-req-build-7ej22y0s/setup.py", line 432, in <module>
        metadata = parse_setup_cfg()
      File "/private/var/folders/kt/j77sf4_n6fnbx6pg199rbx700000gn/T/pip-req-build-7ej22y0s/setup.py", line 216, in parse_setup_cfg
        fp = open(nm, "rU")
    ValueError: invalid mode: 'rU'
    ----------------------------------------
ERROR: Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.

=================================== log end ====================================

================================================================== log end ==================================================================
✖ FAIL py39 in 11.267 seconds
✔ OK py38 in 18.113 seconds
✔ OK flake8 in 11.763 seconds
✔ OK coverage-report in 11.959 seconds
__________________________________________________________________ summary __________________________________________________________________
  isort: commands succeeded
  black: commands succeeded
  py27: commands succeeded
ERROR:   py34: parallel child exit code 1
  py35: commands succeeded
  py36: commands succeeded
  py37: commands succeeded
  py38: commands succeeded
ERROR:   py39: parallel child exit code 1
  flake8: commands succeeded
  coverage-report: commands succeeded
```

# PR

py39 passes (py34 not installed)

```
tox --parallel auto
GLOB sdist-make: /private/tmp/altgraph/setup.py
⠸ [4] isort | black | py27 | py34ERROR: invocation failed (exit code 1), logfile: /private/tmp/altgraph/.tox/py34/log/py34-3.log
================================================================= log start =================================================================
py34 create: /private/tmp/altgraph/.tox/py34
ERROR: InterpreterNotFound: python3.4

================================================================== log end ==================================================================
✖ FAIL py34 in 7.689 seconds
✔ OK black in 13.855 seconds
✔ OK isort in 14.715 seconds
✔ OK py27 in 22.121 seconds
✔ OK py35 in 23.726 seconds
✔ OK py37 in 24.21 seconds
✔ OK py36 in 26.761 seconds
✔ OK py38 in 22.815 seconds
✔ OK py39 in 23.287 seconds
✔ OK flake8 in 16.423 seconds
✔ OK coverage-report in 15.332 seconds
__________________________________________________________________ summary __________________________________________________________________
  isort: commands succeeded
  black: commands succeeded
  py27: commands succeeded
ERROR:   py34: parallel child exit code 1
  py35: commands succeeded
  py36: commands succeeded
  py37: commands succeeded
  py38: commands succeeded
  py39: commands succeeded
  flake8: commands succeeded
  coverage-report: commands succeeded
```

