### PR TITLE
Run tox on GitHub Actions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,35 @@
+name: Lint
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.7]
+        toxenv: [isort, black, flake8]
+
+    steps:
+      - uses: actions/checkout@v1
+
+      - name: pip cache
+        uses: actions/cache@v1
+        with:
+          path: ~/.cache/pip
+          key: ${{ matrix.toxenv }}-pip-${{ hashFiles('**/setup.py') }}
+          restore-keys: |
+            ${{ matrix.toxenv }}-pip-
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v1
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install --upgrade tox
+
+      - name: Lint
+        run: tox -e ${{ matrix.toxenv }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,64 @@
+name: Test
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: [3.5, 3.6, 3.7, 3.8]
+        os: [ubuntu-18.04, ubuntu-16.04, macos-latest, windows-latest]
+
+    steps:
+      - uses: actions/checkout@v1
+
+      - name: Ubuntu cache
+        uses: actions/cache@v1
+        if: startsWith(matrix.os, 'ubuntu')
+        with:
+          path: ~/.cache/pip
+          key:
+            ${{ matrix.os }}-${{ matrix.python-version }}-${{ hashFiles('**/setup.py')
+            }}
+          restore-keys: |
+            ${{ matrix.os }}-${{ matrix.python-version }}-
+
+      - name: macOS cache
+        uses: actions/cache@v1
+        if: startsWith(matrix.os, 'macOS')
+        with:
+          path: ~/Library/Caches/pip
+          key:
+            ${{ matrix.os }}-${{ matrix.python-version }}-${{ hashFiles('**/setup.py')
+            }}
+          restore-keys: |
+            ${{ matrix.os }}-${{ matrix.python-version }}-
+
+      - name: Windows cache
+        uses: actions/cache@v1
+        if: startsWith(matrix.os, 'windows')
+        with:
+          path: ~\AppData\Local\pip\Cache
+          key:
+            ${{ matrix.os }}-${{ matrix.python-version }}-${{ hashFiles('**/setup.py')
+            }}
+          restore-keys: |
+            ${{ matrix.os }}-${{ matrix.python-version }}-
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v1
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install --upgrade tox
+
+      - name: Tox tests
+        shell: bash
+        # Drop the dot: py3.7 -> py37
+        run: |
+          tox -e py`echo ${{ matrix.python-version }} | tr -d .`


### PR DESCRIPTION
For #13.

This creates two workflows:

* One for lint
* One for test

The lint workflow runs on Python 3.7 and runs the isort, black and flake8 tox envs in separate jobs. Takes ~1m48s.

The test workflow is similar, but runs the py35 - py38 tox envs on all the available operating systems: `ubuntu-18.04, ubuntu-16.04, macos-latest, windows-latest`. Takes ~4m30s.

Here's how it looks:

![image](https://user-images.githubusercontent.com/1324225/72814243-64e43280-3c6d-11ea-9086-97d0186d0c40.png)

https://github.com/hugovk/altgraph/commit/223a3706165c611493441858e6f300b68c68ae9c/checks?check_suite_id=412139810
