### PR TITLE
Simplify CI config

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,6 +59,5 @@ jobs:
 
       - name: Tox tests
         shell: bash
-        # Drop the dot: py3.7 -> py37
         run: |
-          tox -e py`echo ${{ matrix.python-version }} | tr -d .`
+          tox -e py


### PR DESCRIPTION
I discovered the workaround is no longer needed, `tox -e py` will run on the Python interpreter it's been installed on.