### PR TITLE
Remove import exception in Python3.12

### DIFF
--- a/altgraph/__init__.py
+++ b/altgraph/__init__.py
@@ -139,9 +139,15 @@ To display the graph we can use the GraphViz backend::
   @contributor: U{Reka Albert <http://www.phys.psu.edu/~ralbert/>}
 
 """
-import pkg_resources
+try:
+    import pkg_resources
 
-__version__ = pkg_resources.require("altgraph")[0].version
+    __version__ = pkg_resources.require("altgraph")[0].version
+except ImportError:
+    # pkg_resources was killed in Python3.12
+    import importlib_metadata
+
+    __version__ = importlib_metadata.version("altgraph")
 
 
 class GraphError(ValueError):

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,6 +36,8 @@ keywords = graph
 platforms = any
 packages = altgraph
 zip-safe = 1
-
+requires-dist =
+	importlib_metadata (>=6.5)
+ 
 [bdist_wheel]
 universal = 1


### PR DESCRIPTION
Python 3.12 doesn't support `png_resources` anymore. We need to circumvent this by using `import lib_metadata` instead.